### PR TITLE
ensure hex values 64 characters in length

### DIFF
--- a/app/secure_key.rb
+++ b/app/secure_key.rb
@@ -6,7 +6,7 @@ require 'securerandom'
 module SecureKey
   DB = Sequel.connect ENV['DATABASE_URL'] || 'postgres:///secure_key'
   def self.generate
-    SecureRandom.random_number(2**256).to_s(16).upcase
+    SecureRandom.hex(32).upcase
   end
 end
 

--- a/spec/secure_key_spec.rb
+++ b/spec/secure_key_spec.rb
@@ -4,4 +4,10 @@ describe SecureKey, ".generate" do
   it 'makes different keys' do
     SecureKey.generate.should_not == SecureKey.generate
   end
+
+  it 'generates hex-encodable keys reliably 64 characters in length' do
+    100.times do
+      SecureKey.generate.length.should == 64
+    end
+  end
 end


### PR DESCRIPTION
Previous method sometimes provides 63 chars.
Guaranteeing 64 chars allows consumers to use hex decoding methods.